### PR TITLE
Fix UNSAFE_STRING_PATTERN to follow the value-spec in RFC 2849

### DIFF
--- a/ldif3.py
+++ b/ldif3.py
@@ -48,7 +48,7 @@ def is_dn(s):
     return rm is not None and rm.group(0) == s
 
 
-UNSAFE_STRING_PATTERN = '(^[ :<]|[\000\n\r\200-\377])'
+UNSAFE_STRING_PATTERN = '(^[^\x01-\x09\x0b-\x0c\x0e-\x1f\x21-\x39\x3b\x3d-\x7f]|[^\x01-\x09\x0b-\x0c\x0e-\x7f])'
 UNSAFE_STRING_RE = re.compile(UNSAFE_STRING_PATTERN)
 
 


### PR DESCRIPTION
The value-spec in RFC 2849:

```
value-spec               = ":" (    FILL 0*1(SAFE-STRING) /
                                ":" FILL (BASE64-STRING) /
                                "<" FILL url)

SAFE-CHAR                = %x01-09 / %x0B-0C / %x0E-7F
                           ; any value <= 127 decimal except NUL, LF,
                           ; and CR

SAFE-INIT-CHAR           = %x01-09 / %x0B-0C / %x0E-1F /
                           %x21-39 / %x3B / %x3D-7F
                           ; any value <= 127 except NUL, LF, CR,
                           ; SPACE, colon (":", ASCII 58 decimal)
                           ; and less-than ("<" , ASCII 60 decimal)

SAFE-STRING              = [SAFE-INIT-CHAR *SAFE-CHAR]
```

I want to unparse dict data that includes Japanese (non-ascii) string value.
Without this fix, ldif3 throws UnicodeEncodeError as the below.

```console
$ python3 -c 'import sys,ldif3; w=ldif3.LDIFWriter(sys.stdout.buffer); w.unparse("o=x",{"test": ["日本語"]})'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/ldif3.py", line 193, in unparse
    self._unparse_entry_record(record)
  File "/usr/lib/python3/dist-packages/ldif3.py", line 144, in _unparse_entry_record
    self._unparse_attr(attr_type, attr_value)
  File "/usr/lib/python3/dist-packages/ldif3.py", line 135, in _unparse_attr
    self._fold_line(line.encode('ascii'))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 6-8: ordinal not in range(128)
```